### PR TITLE
Add some additional name mappings

### DIFF
--- a/name_mappings.yml
+++ b/name_mappings.yml
@@ -1,2 +1,5 @@
 dereine: dawehner
-robloach: rob loach
+rob loach: robloach
+david rothstein: david_rothstein
+davereid: dave reid
+niklas: niklas fiekas


### PR DESCRIPTION
Perhaps `et al` mappings should be handled in the script itself. There are 16 occurrences, wouldn't hurt to list them in the .yaml file, but you never know. Thoughts?
