### PR TITLE
Added mapping to javier.alejandro.castro

### DIFF
--- a/name_mappings.yml
+++ b/name_mappings.yml
@@ -21,3 +21,4 @@ mrfelton. et al: mrfelton
 jasonrsavino et al: jasonrsavino
 marcp et all: marcp
 fubhy the cat: fubhy
+javier.alejandr...: javier.alejandro.castro


### PR DESCRIPTION
Javier Castro (javier.alejandro.castro) didn't get correct nickname because of suspension points in large commit comment.
