### PR TITLE
Use 8.2.x by default

### DIFF
--- a/cores.rb
+++ b/cores.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 log_args = ARGV[0] || '--since=2011-03-09'
-git_command = 'git --git-dir=drupal/.git --work-tree=drupal log 8.0.x ' + log_args + ' -s --format=%s'
+git_command = 'git --git-dir=drupal/.git --work-tree=drupal log 8.2.x ' + log_args + ' -s --format=%s'
 
 Encoding.default_external = Encoding::UTF_8
 require 'erb'


### PR DESCRIPTION
According to our backport policy, 8.2.x will include almost all commits that go into any other branches. 8.0.x does not reflect the full history of D8 contribution (and, in fact, is now a dead branch).
